### PR TITLE
fix duplicate key `commands` in `tests`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: ae7c57ef920589a40270d5ef3216d693f4e6f8864d8fc8b6cb7885ca98ad2a61
 
 build:
-  number: 0
+  number: 1
   script:
     - {{ PYTHON }} -m pip install . -vv
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
@@ -38,11 +38,10 @@ requirements:
 test:
   requires:
     - pip
-  commands:
-    - pip check
   imports:
     - watchfiles
   commands:
+    - pip check
     - watchfiles -h
 
 about:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

@davidbrochart can you check this? Looks like your change in c283f1fddc2d71f4c3293a5edacd9d0dc375a126 caused a duplicate `commands` key which was causing conda's check for updates to error out.

See https://conda-forge.org/status/, go to "Version Updates" and  search for "watchfiles", output:

```
We found a problem parsing the recipe for version '0.17.0': 

DuplicateKeyError('while constructing a mapping',   in "", line 39, column 3:
      requires:
      ^ (line: 39), 'found duplicate key "commands" with value "[\'watchfiles -h\']" (original value: "[\'pip check\']")',   in "", line 45, column 3:
      commands:
      ^ (line: 45), '\n                    To suppress this check see:\n                        http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys\n                    ', '                    Duplicate keys will become an error in future releases, and are errors\n                    by default when using the new API.\n                    ')

traceback:
  File "/home/runner/work/autotick-bot/autotick-bot/cf-scripts/conda_forge_tick/migrators/version.py", line 509, in migrate
    cmeta = CondaMetaYAML(fp.read())
  File "/home/runner/work/autotick-bot/autotick-bot/cf-scripts/conda_forge_tick/recipe_parser/_parser.py", line 494, in __init__
    self.meta = self._parser.load("".join(lines))
  File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/main.py", line 434, in load
    return constructor.get_single_data()
  File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 121, in get_single_data
    return self.construct_document(node)
  File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 131, in construct_document
    for _dummy in generator:
  File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 1569, in construct_yaml_map
    self.construct_mapping(node, data, deep=True)
  File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 1452, in construct_mapping
    value = self.construct_object(value_node, deep=deep)
  File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 154, in construct_object
    data = self.construct_non_recursive_object(node)
  File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 196, in construct_non_recursive_object
    for _dummy in generator:
  File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 1569, in construct_yaml_map
    self.construct_mapping(node, data, deep=True)
  File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 1453, in construct_mapping
    if self.check_mapping_key(node, key_node, maptyp, key, value):
  File "/usr/share/miniconda3/envs/run_env/lib/python3.9/site-packages/ruamel/yaml/constructor.py", line 294, in check_mapping_key
    raise DuplicateKeyError(*args)
```
